### PR TITLE
Update OpenLyricsWriter.java

### DIFF
--- a/Quelea/src/main/java/org/quelea/utils/OpenLyricsWriter.java
+++ b/Quelea/src/main/java/org/quelea/utils/OpenLyricsWriter.java
@@ -104,8 +104,7 @@ public class OpenLyricsWriter {
     public void writeToFile(File xfile, boolean overwrite)
             throws OpenLyricsWriterFileExistsException,
                    OpenLyricsWriterWriteErrorException,
-                   TransformerConfigurationException,
-                   TransformerException {
+                   TransformerException { //                                                                      Removed TransformerConfigurationException 
         if (!overwrite && xfile.exists()) {
             throw new OpenLyricsWriterFileExistsException(String.format("The file %s exists.", xfile.getAbsolutePath()));
         }


### PR DESCRIPTION
Removed TransformerConfigurationException as it extends TransformerException and is not needed to be thrown (line 107). [Also, added a comment in the same line].